### PR TITLE
Don't shrink with proguard in bazel build.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -43,7 +43,6 @@ android_binary(
     srcs = glob(["src/main/java/**/*.java"]),
     custom_package = "im.tox.toktok",
     manifest = "src/main/AndroidManifest.xml",
-    proguard_specs = ["proguard-rules.pro"],
     resource_files = glob(["src/main/res/**"]),
     deps = android_deps + [
         "@org_slf4j_slf4j_android//jar",


### PR DESCRIPTION
It's currently broken. The difference is minor: 3.2 vs. 4.1 MB APK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/toktok-android/49)
<!-- Reviewable:end -->
